### PR TITLE
Simplify pulse sequence instantiation

### DIFF
--- a/qopt/solver_algorithms.py
+++ b/qopt/solver_algorithms.py
@@ -658,7 +658,7 @@ class Solver(ABC):
         return self.pulse_sequence
 
     def plot_bloch_sphere(
-            self, new_amps=None, return_Bloch: bool=False) -> None:
+            self, new_amps=None, return_Bloch: bool = False) -> None:
         """
         Uses the pulse sequence to plot the systems evolution on the bloch
         sphere.
@@ -680,13 +680,9 @@ class Solver(ABC):
             Qutips Bloch object. Only returned if return_Bloch is set to True.
 
         """
-        if new_amps is not None:
-            self.set_optimization_parameters(new_amps)
-
-        if self.pulse_sequence is None:
-            self.create_pulse_sequence(new_amps=new_amps)
-
-        return plotting.plot_bloch_vector_evolution(self.pulse_sequence,
+        # Already takes care of updating and cleaning the PulseSequence object
+        pulse_sequence = self.create_pulse_sequence(new_amps=new_amps)
+        return plotting.plot_bloch_vector_evolution(pulse_sequence,
                                                     n_samples=500,
                                                     return_Bloch=return_Bloch)
 

--- a/qopt/solver_algorithms.py
+++ b/qopt/solver_algorithms.py
@@ -632,6 +632,8 @@ class Solver(ABC):
             basis = ff_basis
         elif self.filter_function_basis is not None:
             basis = self.filter_function_basis
+        else:
+            basis = None
 
         if self.pulse_sequence is None:
             h_n = self.create_ff_h_n

--- a/qopt/solver_algorithms.py
+++ b/qopt/solver_algorithms.py
@@ -636,21 +636,17 @@ class Solver(ABC):
             basis = None
 
         if self.pulse_sequence is None:
-            h_n = self.create_ff_h_n
-            h_c = list(zip(
-                self.h_drift,
-                np.ones((len(self.h_drift), len(self.transferred_time))),
-                [f'Drift{i}' for i in range(len(self.h_drift))]
-            ))
+            h_c = [[self.h_drift[0],
+                    np.ones(len(self.transferred_time)),
+                    'Drift']]
             h_c += list(zip(
                 self.h_ctrl,
                 self._ctrl_amps.T,
                 [f'Control{i}' for i in range(len(self.h_ctrl))]
             ))
-            dt = self.transferred_time
-
-            self.pulse_sequence = pulse_sequence.PulseSequence(h_c, h_n, dt,
-                                                               basis)
+            self.pulse_sequence = pulse_sequence.PulseSequence(
+                h_c, self.create_ff_h_n, self.transferred_time, basis
+            )
         else:
             self.pulse_sequence.cleanup('all')
             self.pulse_sequence.c_coeffs = new_amps.T


### PR DESCRIPTION
As far as I can tell, the optimizer only updates the control amplitudes of the solver object. In that case it's much simpler to just manually set the new amplitudes if a `solver.pulse_sequence` already exists. When updating, we just need to make sure to clear all cached attributes (like the eigendecomposition) of the `PulseSequence` object.

Furthermore, the `PulseSequence` constructor can handle `qopt.DenseOperator`s and the instantiation of the object in `solver.create_pulse_sequence()` can be simplified a bit (once https://github.com/qutech/filter_functions/pull/53 is merged).

With these changes, `solver.plot_bloch_sphere` can also be a bit leaner and just call the `solver.create_pulse_sequence()` method.