### PR TITLE
Added create_ff_h_n for Monte Carlo Schroedinger Equation Solver

### DIFF
--- a/qopt/solver_algorithms.py
+++ b/qopt/solver_algorithms.py
@@ -1047,6 +1047,10 @@ class SchroedingerSMonteCarlo(SchroedingerSolver):
         Frechet derivatives of the propagators by the control amplitudes for
         the individual noise traces.
 
+    create_ff_h_n(self): List[List[np.ndarray, list, str]], 
+        shape [[]]*num_noise_operators
+        Creates the noise hamiltonian of the filter function formalism.
+
     """
     def __init__(
             self, h_drift: List[q_mat.OperatorMatrix],
@@ -1387,6 +1391,30 @@ class SchroedingerSMonteCarlo(SchroedingerSolver):
             raise ValueError('Unknown gradient derivative approximation '
                              'method:'
                              + str(self.frechet_deriv_approx_method))
+
+    @property
+    def create_ff_h_n(self) -> list:
+        """Creates the noise hamiltonian of the filter function formalism.
+
+        Returns
+        -------
+        create_ff_h_n: nested list
+            Noise Hamiltonian of the filter function formalism.
+
+        """
+        if type(self._filter_function_h_n) == list:
+            h_n = self._filter_function_h_n
+        else:
+            h_n = self._filter_function_h_n(self._opt_pars)
+
+        if not h_n:
+            h_n = []
+            for i, noise_operator in enumerate(self.h_noise):
+                if type(noise_operator) == matrix.DenseOperator:
+                    noise_operator = noise_operator.data
+                h_n += [[noise_operator, len(self.transferred_time) * [1], 'Noise' + str(i)], ]
+
+        return h_n
 
 
 class SchroedingerSMCControlNoise(SchroedingerSMonteCarlo):


### PR DESCRIPTION
Added create_ff_h_n function for easy filter function calculation from Monte Carlo Schrödinger Equation Solver:

``` python
...
ffps= schroedinger_mc_solver.create_pulse_sequence()

omega = ff.util.get_sample_frequencies(ffps)
F = ffps.get_filter_function(omega)

from filter_functions import plotting
plotting.plot_filter_function(ffps)

```