### PR TITLE
Added mpl cmap to plot_energy_spectrum

### DIFF
--- a/qopt/energy_spectrum.py
+++ b/qopt/energy_spectrum.py
@@ -61,14 +61,14 @@ def vector_color_map(vectors: np.array):
 
     """
     assert len(vectors.shape) == 2
-    
-    points_on_cmap = np.linspace(0, 1, vectors.shape[-1]) # The ends of 'gist_rainbow' are very similar, thus 'gist_rainbow' will only be queried up to the blue tones. If one wants to use 'rainbow', one might want to change the range to [0, 1]
+
+    points_on_cmap = np.linspace(0, 1, vectors.shape[-1])
     basis_colors = mpl.cm.get_cmap('brg')(points_on_cmap)
     basis_colors = np.array(basis_colors)[:, :-1]
     
     values = np.einsum('ij, ni -> nj', basis_colors, np.abs(vectors))
 
-    # in this basis, the normalization to the rgb range is not preserved, thus it needs to be renormalized. But the colors get very bland/grey.
+    # in this basis, the normalization to the rgb range is not preserved, thus it needs to be renormalized. 
     values /= np.max(values, axis=-1)[..., None]
 
     return values

--- a/qopt/energy_spectrum.py
+++ b/qopt/energy_spectrum.py
@@ -34,6 +34,7 @@ Functions
 
 """
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -60,16 +61,16 @@ def vector_color_map(vectors: np.array):
 
     """
     assert len(vectors.shape) == 2
-    n = vectors.shape[0]
-    basis = np.asarray([
-        [1, 0, 0, 1, 1, 0, 1],
-        [0, 1, 0, 1, 0, 1, 1],
-        [0, 0, 1, 0, 1, 1, 1]
-    ])
-    basis = basis[:, :vectors.shape[1]]
-    values = np.einsum('ni,ji -> nj', np.abs(vectors), basis)
-    for i in range(n):
-        values[i, :] /= np.linalg.norm(values[i, :])
+    
+    points_on_cmap = np.linspace(0, 1, vectors.shape[-1]) # The ends of 'gist_rainbow' are very similar, thus 'gist_rainbow' will only be queried up to the blue tones. If one wants to use 'rainbow', one might want to change the range to [0, 1]
+    basis_colors = mpl.cm.get_cmap('brg')(points_on_cmap)
+    basis_colors = np.array(basis_colors)[:, :-1]
+    
+    values = np.einsum('ij, ni -> nj', basis_colors, np.abs(vectors))
+
+    # in this basis, the normalization to the rgb range is not preserved, thus it needs to be renormalized. But the colors get very bland/grey.
+    values /= np.max(values, axis=-1)[..., None]
+
     return values
 
 


### PR DESCRIPTION
Added a dynamic method for obtaining colours for `plot_energy_spectrum` using mpl cmaps. 
With this, energy spectra of Hamiltonians with multiple dimensions can be plotted.

![image](https://user-images.githubusercontent.com/9484174/157465524-0c51f021-88da-4f63-97d5-cc31fd90cbb6.png)
