### PR TITLE
Remove coverage report

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -35,12 +35,3 @@ jobs:
       run: |
         python -m pytest qopt_tests --cov=qopt --cov-report=xml
         # it is important to use python -m because it adds the current directory to the path!
-
-# Coverage upload fails and requires revisiting
-#    - name: Upload code coverage
-#      uses: codecov/codecov-action@v2
-#      with:
-#        file: ./coverage.xml
-#        name: ${{ matrix.python-version }}
-#        env_vars: OS,PYTHON
-#        fail_ci_if_error: true

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -35,11 +35,12 @@ jobs:
       run: |
         python -m pytest qopt_tests --cov=qopt --cov-report=xml
         # it is important to use python -m because it adds the current directory to the path!
-        
-    - name: Upload code coverage
-      uses: codecov/codecov-action@v2
-      with:
-        file: ./coverage.xml
-        name: ${{ matrix.python-version }}
-        env_vars: OS,PYTHON
-        fail_ci_if_error: true
+
+# Coverage upload fails and requires revisiting
+#    - name: Upload code coverage
+#      uses: codecov/codecov-action@v2
+#      with:
+#        file: ./coverage.xml
+#        name: ${{ matrix.python-version }}
+#        env_vars: OS,PYTHON
+#        fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Documentation Status](https://img.shields.io/readthedocs/qopt)](https://qopt.readthedocs.io/en/latest/)
 [![PyPI version](https://img.shields.io/pypi/v/qopt)](https://pypi.org/project/qopt/)
 [![License](https://img.shields.io/github/license/qutech/qopt)](https://github.com/qutech/qopt/blob/master/LICENSE)
-[![codecov](https://codecov.io/gh/qutech/qopt/branch/master/graph/badge.svg)](https://app.codecov.io/gh/qutech/qopt)
 
 ## Documentation
 The documentation can be found on 


### PR DESCRIPTION
The coverage upload in the current configuration fails due to rate limitations and fixing was more than 5 minutes of work so I decided to remove the report and the badge as this is a low priority task and currently only creates noise.